### PR TITLE
Update requirements for psycopg2cffi

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ BeautifulSoup==3.2.1
 PyMySQL==0.9.3
 httplib2==0.9.2
 netifaces==0.10.4
-psycopg2cffi==2.7.4
+psycopg2cffi==2.7.7
 html5lib==0.9999999
 chardet==2.3.0
 pandas==0.24.2


### PR DESCRIPTION
Fixes this error with PostgreSQL 12.5
Collecting psycopg2cffi==2.7.4
  Using cached psycopg2cffi-2.7.4.tar.gz (62 kB)
    ERROR: Command errored out with exit status 1:
     command: /usr/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-i8hAs8/psycopg2cffi/setup.py'"'"'; __file__='"'"'/tmp/pip-install-i8hAs8/psycopg2cffi/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-y101_D
         cwd: /tmp/pip-install-i8hAs8/psycopg2cffi/
    Complete output (7 lines):
    Error: could not determine PostgreSQL version from '12.5'
    ================================================================================
    
    Found libpq at:
     -> /usr/lib/x86_64-linux-gnu/libpq.so
    
    ================================================================================
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.